### PR TITLE
added find_package(PythonInterp 3) to SWIG cmake

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -30,6 +30,7 @@ endif(NOT grnet_sources)
 # Include swig generation macros
 ########################################################################
 find_package(SWIG)
+find_package(PythonInterp 3)
 find_package(PythonLibs)
 if(NOT SWIG_FOUND OR NOT PYTHONLIBS_FOUND)
     return()


### PR DESCRIPTION
Couldn't get it to work on Ubuntu 18 with GR 3.8 till I added this